### PR TITLE
Fixed AndroidManifest file with missed place action and category tags

### DIFF
--- a/plugin/platforms/android/AndroidManifest.xml
+++ b/plugin/platforms/android/AndroidManifest.xml
@@ -7,9 +7,13 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.VIBRATE" />
     
-    <action android:name="android.intent.action.MAIN" />
- 
-    <category android:name="android.intent.category.LAUNCHER" />
+
+    <intent-filter>
+		<action android:name="android.intent.action.MAIN" />
+		<category android:name="android.intent.category.LAUNCHER" />
+	</intent-filter>
+	
+    
 
     <uses-feature android:name="android.hardware.camera"
                   android:required="false" />


### PR DESCRIPTION
After upgrading to nativescript 5.0.5, I get this error: 

`Execution failed for task ':verifyReleaseResources'.
> java.util.concurrent.ExecutionException: com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
  Output:  D:\projects\dci\kwl\kwl-mobile\platforms\tempPlugin\nativescript_paypal\build\intermediates\aapt_friendly_merged_manifests\release\processReleaseManifest\aapt\AndroidManifest.xml:15: error: unexpected element <action> found in <manifest>.
  D:\projects\dci\kwl\kwl-mobile\platforms\tempPlugin\nativescript_paypal\build\intermediates\aapt_friendly_merged_manifests\release\processReleaseManifest\aapt\AndroidManifest.xml:17: error: unexpected element <category> found in <manifest>.`

according to this thread the solution would simply be to wrap the tags in a intent-filter:

https://stackoverflow.com/questions/46948498/android-studio-3-0-manifest-error-unknown-element-action-found